### PR TITLE
[FEATURE] Course age filtering  #42aeqt

### DIFF
--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -375,7 +375,22 @@ class ListingsResults extends PureComponent {
             client_location_name: node.node.client_location_name,
             courses: node.node.courses
               .filter(course => course.category_group_name.includes(filter))
-              .filter(course  => course.age_range_start <= this.state.ageFilter.ageMin && course.age_range_end >= this.state.ageFilter.ageMax),
+              .filter(course  => {
+                // Return all courses on page load
+                if (this.state.ageFilter.ageMin === 0 && this.state.ageFilter.ageMax === 0) return course
+                // Return courses for ages < 5
+                if (this.state.ageFilter.ageMin === 0 && course.age_range_end < this.state.ageFilter.ageMax) {
+                  return course
+                }
+                // Return course for ages over 10
+                if (this.state.ageFilter.ageMax === null && course.age_range_start <= this.state.ageFilter.ageMin && course.age_range_end >= this.state.ageFilter.ageMin) {
+                  return course
+                }
+                // Return courses for a specific age (5-9)
+                if (course.age_range_start <= this.state.ageFilter.ageMin &&
+                    course.age_range_end >= this.state.ageFilter.ageMax) {
+                  return course
+                }}),
             display_address: node.node.display_address,
             county_id: node.node.county_id,
             state_id: node.node.state_id,

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -375,7 +375,7 @@ class ListingsResults extends PureComponent {
             client_location_name: node.node.client_location_name,
             courses: node.node.courses
               .filter(course => course.category_group_name.includes(filter))
-              .filter(course  => course.age_range_start <= this.state.ageFilter && course.age_range_end >= this.state.ageFilter),
+              .filter(course  => course.age_range_start <= this.state.ageFilter.ageMin && course.age_range_end >= this.state.ageFilter.ageMax),
             display_address: node.node.display_address,
             county_id: node.node.county_id,
             state_id: node.node.state_id,
@@ -405,7 +405,7 @@ class ListingsResults extends PureComponent {
             <ListingsCounters
               categoryFilter={categoryFilter}
               toggleCategoryFilter={this.props.toggleCategoryFilter}
-              courseData={geoFilteredCourseData}
+              courseData={filteredCourseDataByToggle(categoryFilter)}
             />
           </div>
         </CourseListingsStyle.Toolbar>

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -394,7 +394,7 @@ class ListingsResults extends PureComponent {
             client_location_name: node.node.client_location_name,
             courses: node.node.courses
               .filter(course => course.category_group_name.includes(filter))
-              .filter(course  => filteredCourseByAge(course)),
+              .filter(filteredCourseByAge),
             display_address: node.node.display_address,
             county_id: node.node.county_id,
             state_id: node.node.state_id,

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -600,6 +600,10 @@ class CourseListings extends PureComponent {
     }
   }
 
+  componentDidUpdate() {
+    this.updateURL();
+  }
+
   componentDidMount() {
     /**
      *

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -370,18 +370,24 @@ class ListingsResults extends PureComponent {
 
     const filteredCourseByAge = course => {
       // Return all courses on page load
-      if (ageFilter.ageMin === 0 && ageFilter.ageMax === 0) return course
+      if (ageFilter.ageMin === 0 &&
+          ageFilter.ageMax === 0) {
+        return course
+      }
       // Return courses for ages < 5
-      else if (ageFilter.ageMin === 0 && course.age_range_start <= ageFilter.ageMax && course.age_range_end <= ageFilter.ageMax) {
+      else if (ageFilter.ageMin === 0 &&
+              course.age_range_start <= ageFilter.ageMax &&
+              course.age_range_end <= ageFilter.ageMax) {
         return course
       }
       // Return course for ages over 10
-      else if (course.age_range_start <= ageFilter.ageMin && course.age_range_end >= ageFilter.ageMin) {
+      else if (course.age_range_start <= ageFilter.ageMin &&
+              course.age_range_end >= ageFilter.ageMin) {
         return course
       }
       // Return courses for a specific age (5-9)
       else if (course.age_range_start <= ageFilter.ageMin &&
-          course.age_range_end >= ageFilter.ageMax) {
+              course.age_range_end >= ageFilter.ageMax) {
         return course
       }
     }

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -321,6 +321,7 @@ class ListingsResults extends PureComponent {
       startDate: '',
       courseTypes: [],
       results: [],
+      ageFilter: null,
     };
   }
 
@@ -365,19 +366,15 @@ class ListingsResults extends PureComponent {
         }
       }, this);
 
-    const filteredCourseDataByToggle = d =>
+    const filteredCourseDataByToggle = filter =>
       geoFilteredCourseData.map((node, idx) => {
         return {
           node: {
             client_id: node.node.id,
             client_location_name: node.node.client_location_name,
-            courses: node.node.courses.filter((course, idxx) => {
-              // Define our query
-              const filter = d;
-
-              // Set up the conditions
-              return course.category_group_name.includes(filter);
-            }, this),
+            courses: node.node.courses
+              .filter(course => course.category_group_name.includes(filter))
+              .filter(course  => course.age_range_start <= this.state.ageFilter && course.age_range_end >= this.state.ageFilter),
             display_address: node.node.display_address,
             county_id: node.node.county_id,
             state_id: node.node.state_id,
@@ -391,11 +388,16 @@ class ListingsResults extends PureComponent {
         };
       }, this);
 
+      const setListingFilter = (name, value) => {
+        this.setState({ [name]: value })
+      }
+
     return (
       <>
         <CourseListingsStyle.Toolbar>
           <div className="toolbar-inner">
             <ListingsFilters
+              setListingFilter={setListingFilter}
               categoryFilter={categoryFilter}
               courseData={geoFilteredCourseData}
             />
@@ -587,7 +589,7 @@ class CourseListings extends PureComponent {
         style: 'mapbox://styles/mapbox/streets-v9',
         maxZoom: 11,
       });
-    
+
 
       this.map = map;
 

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -315,13 +315,14 @@ class ListingsResults extends PureComponent {
       lat: [],
       lng: [],
       zoom: [],
-      ageMin: 0,
-      ageMax: 0,
       startDate: '',
       startDate: '',
       courseTypes: [],
       results: [],
-      ageFilter: null,
+      ageFilter: {
+        ageMin: 0,
+        ageMax: 0
+      },
     };
   }
 

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -492,11 +492,13 @@ class CourseListings extends PureComponent {
 
   // Function to update our url query parameters when we change
   // categories & filters to create sharable urls.
-  setParams({ show = '', age_min = '', age_max = '' }) {
+  setParams({ show = '', age_min, age_max }) {
     const searchParams = new URLSearchParams();
     searchParams.set('show', show);
-    searchParams.set('age_min', age_min);
-    searchParams.set('age_max', age_max);
+    if (age_min !== undefined && age_max !== undefined) {
+      searchParams.set('age_min', age_min);
+      searchParams.set('age_max', age_max);
+    }
     return searchParams.toString();
   }
 
@@ -513,6 +515,7 @@ class CourseListings extends PureComponent {
       history.pushState({}, '', `?${url}`);
     } else if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
       const url = this.setParams({
+        show: 'all',
         age_min: this.state.ageFilter.ageMin,
         age_max: this.state.ageFilter.ageMax
       });

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -319,10 +319,6 @@ class ListingsResults extends PureComponent {
       startDate: '',
       courseTypes: [],
       results: [],
-      ageFilter: {
-        ageMin: 0,
-        ageMax: 0
-      },
     };
   }
 
@@ -339,6 +335,11 @@ class ListingsResults extends PureComponent {
 
     // Filter Categories
     const categoryFilter = this.props.categoryFilter;
+    const ageFilter = this.props.ageFilter;
+
+    // Filter update function
+    const setListingFilter = this.props.setListingFilter
+
     const geoFilteredCourseData = courseData.allPlayWellClient.edges
       .map((node, idx) => {
         return {
@@ -377,18 +378,18 @@ class ListingsResults extends PureComponent {
               .filter(course => course.category_group_name.includes(filter))
               .filter(course  => {
                 // Return all courses on page load
-                if (this.state.ageFilter.ageMin === 0 && this.state.ageFilter.ageMax === 0) return course
+                if (ageFilter.ageMin === 0 && ageFilter.ageMax === 0) return course
                 // Return courses for ages < 5
-                if (this.state.ageFilter.ageMin === 0 && course.age_range_end < this.state.ageFilter.ageMax) {
+                if (ageFilter.ageMin === 0 && course.age_range_end < ageFilter.ageMax) {
                   return course
                 }
                 // Return course for ages over 10
-                if (this.state.ageFilter.ageMax === null && course.age_range_start <= this.state.ageFilter.ageMin && course.age_range_end >= this.state.ageFilter.ageMin) {
+                if (ageFilter.ageMax === null && course.age_range_start <= ageFilter.ageMin && course.age_range_end >= ageFilter.ageMin) {
                   return course
                 }
                 // Return courses for a specific age (5-9)
-                if (course.age_range_start <= this.state.ageFilter.ageMin &&
-                    course.age_range_end >= this.state.ageFilter.ageMax) {
+                if (course.age_range_start <= ageFilter.ageMin &&
+                    course.age_range_end >= ageFilter.ageMax) {
                   return course
                 }}),
             display_address: node.node.display_address,
@@ -403,10 +404,6 @@ class ListingsResults extends PureComponent {
           },
         };
       }, this);
-
-      const setListingFilter = (name, value) => {
-        this.setState({ [name]: value })
-      }
 
     return (
       <>
@@ -464,7 +461,10 @@ class CourseListings extends PureComponent {
       // Filtering
       categoryFilter: '',
       currentlyViewing: '',
-
+      ageFilter: {
+        ageMin: 0,
+        ageMax: 0
+      },
       /**
        *
        * Mapbox settings
@@ -479,6 +479,7 @@ class CourseListings extends PureComponent {
     this.mapBoxRef = React.createRef();
 
     // Bind our functions
+    this.setListingFilter = this.setListingFilter.bind(this);
     this.toggleCategoryFilter = this.toggleCategoryFilter.bind(this);
     this.checkforFilterUrlParam = this.checkforFilterUrlParam.bind(this);
     this.checkforLocationUrlParam = this.checkforLocationUrlParam.bind(this);
@@ -498,6 +499,8 @@ class CourseListings extends PureComponent {
   updateURL() {
     // If we are indeed filtering:
     if (this.state.categoryFilter != '') {
+      // Are we also filtering on age?
+      //if (this.state.ageFilter)
       const url = this.setParams({
         show: this.state.categoryFilter.toLowerCase() + 's',
       });
@@ -533,6 +536,11 @@ class CourseListings extends PureComponent {
         this.updateURL
       );
     }
+  }
+
+  // Our function to update the listing filters for age, date, and course type
+  setListingFilter(name, value) {
+    this.setState({ [name]: value })
   }
 
   // Check for url query for showing/hiding results.
@@ -800,6 +808,8 @@ class CourseListings extends PureComponent {
                 pageContext={pageContext}
                 urlQuery={search.show} // Utilizes our withLocation(); function at the end of this document.
                 categoryFilter={this.state.categoryFilter}
+                ageFilter={this.state.ageFilter}
+                setListingFilter={this.setListingFilter}
                 toggleCategoryFilter={this.toggleCategoryFilter}
                 allCostCodes={allCostCodes}
               />

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -7,7 +7,7 @@
 // Core
 import React from 'react';
 import { Link } from 'gatsby';
-import { range, uniqWith } from 'lodash.get'
+import { range, uniqWith, isEqual } from 'lodash'
 
 // Constants
 import { Base } from 'constants/styles/Base';
@@ -62,15 +62,18 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
         } else {
           return { name: `Age ${age}`, value: { ageMin: age, ageMax: age} }
         }
-      }))
+      }), isEqual)
       return ageFilterItems
   }
+
+  const courses = courseData.map(data => data.node.courses).flat()
+
   // Show the bar
   return (
     <ListingsFiltersStyle>
       <ListingsFiltersItem
         label="Any Age"
-        items={createAgeFilterItems(courseData)}
+        items={createAgeFilterItems(courses)}
         filterName="ageFilter"
         setListingFilter={setListingFilter}
       />

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -7,6 +7,7 @@
 // Core
 import React from 'react';
 import { Link } from 'gatsby';
+import { range, uniqWith } from 'lodash.get'
 
 // Constants
 import { Base } from 'constants/styles/Base';
@@ -43,20 +44,33 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
     );
   };
 
+  const getAgeList = (courses => {
+    const ageList = courses.map(course => (
+      range(course.age_range_start, course.age_range_end + 1)
+    )).flat().sort((a,b) => (a-b));
+    return ageList
+  })
+
+  const createAgeFilterItems = courses => {
+    const ageList = getAgeList(courses)
+    const ageFilterItems = uniqWith(ageList
+      .map(age => {
+        if (age < 5) {
+          return { name: `Under 5`, value: { ageMin: 0, ageMax: 5} }
+        } else if ( age >= 10) {
+          return { name: `10 and over`, value: { ageMin: 10, ageMax: null } }
+        } else {
+          return { name: `Age ${age}`, value: { ageMin: age, ageMax: age} }
+        }
+      }))
+      return ageFilterItems
+  }
   // Show the bar
   return (
     <ListingsFiltersStyle>
       <ListingsFiltersItem
         label="Any Age"
-        items={[
-          { name: 'Under 5', value: 5 },
-          { name: 'Age 5', value: 5 },
-          { name: 'Age 6', value: 6 },
-          { name: 'Age 7', value: 7 },
-          { name: 'Age 8', value: 8 },
-          { name: 'Age 9', value: 9 },
-          { name: '10 and over', value: 10 },
-        ]}
+        items={createAgeFilterItems(courseData)}
         filterName="ageFilter"
         setListingFilter={setListingFilter}
       />

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -7,7 +7,7 @@
 // Core
 import React from 'react';
 import { Link } from 'gatsby';
-import { range, uniqWith, isEqual } from 'lodash'
+import { range, uniqWith, isEqual, flatten } from 'lodash'
 
 // Constants
 import { Base } from 'constants/styles/Base';
@@ -46,15 +46,17 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
     );
   };
 
-  const getAgeList = (courses => {
+  const getAllAges = (courses => {
     const ageList = courses.map(course => (
       range(course.age_range_start, course.age_range_end + 1)
-    )).flat().sort((a,b) => (a-b));
-    return ageList
+    ));
+    const mergedAgeList = flatten(ageList);
+    const sortedAges = mergedAgeList.sort((a,b) => (a-b));
+    return sortedAges
   })
 
   const createAgeFilterItems = courses => {
-    const ageList = getAgeList(courses)
+    const ageList = getAllAges(courses)
     const ageFilterItems = uniqWith(ageList
       .map(age => {
         if (age < 5) {
@@ -68,7 +70,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
       return ageFilterItems
   }
 
-  const courses = courseData.map(data => data.node.courses).flat()
+  const courses = flatten(courseData.map(data => data.node.courses))
 
   // Show the bar
   return (

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -60,7 +60,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
     const ageFilterItems = uniqWith(ageList
       .map(age => {
         if (age < 5) {
-          return { name: `Under 5`, value: { ageMin: 0, ageMax: 5} }
+          return { name: `Under 5`, value: { ageMin: 0, ageMax: 5 } }
         } else if ( age >= 10) {
           return { name: `10 and over`, value: { ageMin: 10, ageMax: 14 } }
         } else {

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -58,7 +58,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
         if (age < 5) {
           return { name: `Under 5`, value: { ageMin: 0, ageMax: 5} }
         } else if ( age >= 10) {
-          return { name: `10 and over`, value: { ageMin: 10, ageMax: null } }
+          return { name: `10 and over`, value: { ageMin: 10, ageMax: 10 } }
         } else {
           return { name: `Age ${age}`, value: { ageMin: age, ageMax: age} }
         }

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -60,7 +60,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
         if (age < 5) {
           return { name: `Under 5`, value: { ageMin: 0, ageMax: 5} }
         } else if ( age >= 10) {
-          return { name: `10 and over`, value: { ageMin: 10, ageMax: 10 } }
+          return { name: `10 and over`, value: { ageMin: 10, ageMax: 14 } }
         } else {
           return { name: `Age ${age}`, value: { ageMin: age, ageMax: age} }
         }

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -21,9 +21,9 @@ import { ListingsFiltersStyle } from './styles.scss';
 // Begin Component
 //////////////////////////////////////////////////////////////////////
 
-export const ListingsFilters = ({ courseData }) => {
+export const ListingsFilters = ({ courseData, setListingFilter }) => {
   // The Items
-  const ListingsFiltersItem = ({ label, items }) => {
+  const ListingsFiltersItem = ({ label, items, filterName }) => {
     return (
       <ListingsFiltersStyle.Item>
         <span className="filter-inner">
@@ -32,9 +32,11 @@ export const ListingsFilters = ({ courseData }) => {
         </span>
         <ListingsFiltersStyle.FilterList className="list">
           <ul>
-            {items.map((item, idx) => {
-              return <li key={idx}>{item.name}</li>;
-            })}
+            {items.map((item, idx) => (
+              <div key={idx} onClick={() => setListingFilter(filterName, item.value)} onKeyDown={() => setListingFilter(filterName, item.value)} role="presentation">
+                <li>{item.name}</li>
+              </div>
+            ))}
           </ul>
         </ListingsFiltersStyle.FilterList>
       </ListingsFiltersStyle.Item>
@@ -55,6 +57,8 @@ export const ListingsFilters = ({ courseData }) => {
           { name: 'Age 9', value: 9 },
           { name: '10 and over', value: 10 },
         ]}
+        filterName="ageFilter"
+        setListingFilter={setListingFilter}
       />
 
       <ListingsFiltersItem

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -7,7 +7,10 @@
 // Core
 import React from 'react';
 import { Link } from 'gatsby';
-import { range, uniqWith, isEqual, flatten } from 'lodash'
+import range from 'lodash/range'
+import flatten from 'lodash/flatten'
+import isEqual from 'lodash/isEqual'
+import uniqWith from 'lodash/uniqWith'
 
 // Constants
 import { Base } from 'constants/styles/Base';

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -32,6 +32,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
           <Icon Name="carat" />
         </span>
         <ListingsFiltersStyle.FilterList className="list">
+          {items.length > 1 &&
           <ul>
             {items.map((item, idx) => (
               <div key={idx} onClick={() => setListingFilter(filterName, item.value)} onKeyDown={() => setListingFilter(filterName, item.value)} role="presentation">
@@ -39,6 +40,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
               </div>
             ))}
           </ul>
+         }
         </ListingsFiltersStyle.FilterList>
       </ListingsFiltersStyle.Item>
     );


### PR DESCRIPTION
# Overview

Add functionality to support filtering listed programs in a given location by a specific age range.

## Details
* Add an Array.filter method to filter based on selected age filter (< 5, 5, 6, 7, 8, 9, or > 10)
* Dynamically populate the drop down list for only those age ranges that are available for the given list of courses.
* Apply filter to the list of course being displayed when drop down item is selected.
* Update the listings counters to reflect the correct number of courses displayed.
* Lock drop down list if only one age filter item is returned.
* Update the URL to show filters that are currently being applied.

## QA Instructions

* Visit the [programs page](https://5e488ce4dbc01a0007de9e1d--play-well-staging.netlify.com/programs/) on the Playwell staging site.
* Enter in a location.
* Selecting an age from the drop down should update the list of courses for that age range.
* Selecting an age from the drop down should update the label of the drop down.
* Selecting an age from the drop down should update the course counters below the drop down.
* Selecting an age from the drop down should update the url with the query parameters for `age_min` and `age_max`

[#42aeqt](https://app.clickup.com/t/42aeqt)