### PR TITLE
[FEATURE] Course type filtering #42aer1

### DIFF
--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -549,71 +549,81 @@ class CourseListings extends PureComponent {
       let safeUrlQuery = this.props.search.show.toLowerCase(); // Via Reach Router
 
       if (safeUrlQuery === 'workshops') {
-        this.setState({
+        this.setState(prevState => ({
+          ...prevState,
           categoryFilter: 'Workshop',
-        });
+        }));
       }
 
       if (safeUrlQuery === 'camps') {
-        this.setState({
+        this.setState(prevState => ({
+          ...prevState,
           categoryFilter: 'Camp',
-        });
+        }));
       }
 
       if (safeUrlQuery === 'courses') {
-        this.setState({
+        this.setState(prevState => ({
+          ...prevState,
           categoryFilter: 'Course',
-        });
+        }));
       }
     } else {
-      this.setState({
-        categoryFilter: ''
-      })
+      this.setState(prevState => ({
+        ...prevState,
+        categoryFilter: '',
+      }))
     }
 
     // Set the ageFilter state based on query params
     if (this.props.search.age_min !== undefined && this.props.search.age_max !== undefined) {
-      this.setState({
+      this.setState(prevState => ({
+        ...prevState,
         ageFilter: {
           ageMin: this.props.search.age_min,
           ageMax: this.props.search.age_max
         }
-      })
+      }))
     } else {
-      this.setState({
+      this.setState(prevState => ({
+        ...prevState,
         ageFilter: {
           ageMin: 0,
           ageMax: 0
         }
-      })
+      }))
     }
 
     // Set the dateFilter state based on query params
     if (this.props.search.date_min !== undefined && this.props.search.date_max !== undefined) {
-      this.setState({
+      this.setState(prevState => ({
+        ...prevState,
         dateFilter: {
           startDate: new Date(this.props.search.date_min),
           endDate: new Date(this.props.search.date_max)
         }
-      })
+      }))
     } else {
-      this.setState({
+      this.setState(prevState => ({
+        ...prevState,
         dateFilter: {
           startDate: '',
           endDate: ''
         }
-      })
+      }))
     }
 
     // Set the courseTypeFilter state based on query params
     if (this.props.search.course_type !== undefined) {
-      this.setState({
+      this.setState(prevState => ({
+        ...prevState,
         courseTypeFilter: this.props.search.course_type
-      })
+      }))
     } else {
-      this.setState({
+      this.setState(prevState => ({
+        ...prevState,
         courseTypeFilter: ''
-      })
+      }))
     }
 
     return;

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -442,7 +442,7 @@ class ListingsResults extends PureComponent {
             />
             <ListingsCounters
               categoryFilter={categoryFilter}
-              toggleCategoryFilter={this.props.toggleCategoryFilter}
+              setListingFilter={setListingFilter}
               courseData={filteredCourseDataBySelection(categoryFilter)}
             />
           </div>
@@ -505,85 +505,40 @@ class CourseListings extends PureComponent {
       lng: -73.9888,
       zoom: 2,
     };
-    const location = this.props.location;
-    console.log(location);
+
     // Create our Map Ref
     this.mapBoxRef = React.createRef();
 
     // Bind our functions
     this.setListingFilter = this.setListingFilter.bind(this);
-    this.toggleCategoryFilter = this.toggleCategoryFilter.bind(this);
     this.checkforFilterUrlParam = this.checkforFilterUrlParam.bind(this);
     this.checkforLocationUrlParam = this.checkforLocationUrlParam.bind(this);
-    this.setParams = this.setParams.bind(this);
     this.updateURL = this.updateURL.bind(this);
-  }
-
-  // Function to update our url query parameters when we change
-  // categories & filters to create sharable urls.
-  setParams({ show = '', age_min, age_max }) {
-    const searchParams = new URLSearchParams();
-    searchParams.set('show', show);
-    if (age_min !== undefined && age_max !== undefined) {
-      searchParams.set('age_min', age_min);
-      searchParams.set('age_max', age_max);
-    }
-    return searchParams.toString();
   }
 
   // Functon to update our URL using history.push API
   updateURL() {
     if (this.state.categoryFilter !== '') {
-      if (this.state.courseTypeFilter !== '') {
-        setQuery({course_type: this.state.courseTypeFilter})
-      }
-      if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
-        setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
-      }
-      if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
-        setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
-      }
-      setQuery({show: this.state.categoryFilter.toLowerCase() + 's'}, {pushState: true})
-    } else {
-      if (this.state.courseTypeFilter !== '') {
-        setQuery({course_type: this.state.courseTypeFilter})
-      }
-      if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
-        setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
-      }
-      if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
-        setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
-      }
+      setQuery({show: this.state.categoryFilter}, {pushState: true})
+    }
+    if (this.state.categoryFilter === '') {
       setQuery({show: 'all'}, {pushState: true})
     }
-
-  }
-
-  // Our Function to Toggle Categories
-  toggleCategoryFilter(context) {
-    if (this.state.categoryFilter == context) {
-      this.setState(
-        {
-          categoryFilter: '',
-        },
-        // Use updateURL as a callback to confirm state.
-        this.updateURL
-      );
-    } else {
-      this.setState(
-        {
-          categoryFilter: context,
-        },
-        // Use updateURL as a callback to confirm state.
-        this.updateURL
-      );
+    if (this.state.courseTypeFilter !== '') {
+      setQuery({course_type: this.state.courseTypeFilter}, {pushState: true})
     }
+    if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
+      setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
+    }
+    if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
+      setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
+    }
+
   }
 
-  // Our function to update the listing filters for age, date, and course type
+  // Our function to update the listing filters for category, age, date, and course type
   setListingFilter(name, value) {
-    this.setState({ [name]: value })
-    this.updateURL()
+    this.setState({ [name]: value }, this.updateURL)
   }
 
   // Check for url query for showing/hiding results.
@@ -622,6 +577,7 @@ class CourseListings extends PureComponent {
 
     // Set the dateFilter state based on query params
     if (this.props.search.date_min !== undefined && this.props.search.date_max !== undefined) {
+      console.log('Date!!')
       this.setState({
         dateFilter: {
           startDate: new Date(this.props.search.date_min),
@@ -657,20 +613,14 @@ class CourseListings extends PureComponent {
     }
   }
 
-  componentDidUpdate() {
-    this.updateURL();
-  }
-
   componentDidMount() {
     /**
      *
      * Check for Url Parameters
      *
      */
-
-    this.checkforFilterUrlParam();
     this.checkforLocationUrlParam();
-
+    this.checkforFilterUrlParam();
     /**
      *
      * Initialize MapboxGL
@@ -886,7 +836,6 @@ class CourseListings extends PureComponent {
                 dateFilter={this.state.dateFilter}
                 courseTypeFilter={this.state.courseTypeFilter}
                 setListingFilter={this.setListingFilter}
-                toggleCategoryFilter={this.toggleCategoryFilter}
                 allCostCodes={allCostCodes}
               />
             </ListingsWrapper>

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -505,7 +505,8 @@ class CourseListings extends PureComponent {
       lng: -73.9888,
       zoom: 2,
     };
-
+    const location = this.props.location;
+    console.log(location);
     // Create our Map Ref
     this.mapBoxRef = React.createRef();
 
@@ -607,6 +608,33 @@ class CourseListings extends PureComponent {
           categoryFilter: 'Course',
         });
       }
+    }
+
+    // Set the ageFilter state based on query params
+    if (this.props.search.age_min !== undefined && this.props.search.age_max !== undefined) {
+      this.setState({
+        ageFilter: {
+          ageMin: this.props.search.age_min,
+          ageMax: this.props.search.age_max
+        }
+      })
+    }
+
+    // Set the dateFilter state based on query params
+    if (this.props.search.date_min !== undefined && this.props.search.date_max !== undefined) {
+      this.setState({
+        dateFilter: {
+          startDate: new Date(this.props.search.date_min),
+          endDate: new Date(this.props.search.date_max)
+        }
+      })
+    }
+
+    // Set the courseTypeFilter state based on query params
+    if (this.props.search.course_type !== undefined) {
+      this.setState({
+        courseTypeFilter: this.props.search.course_type
+      })
     }
 
     return;

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -511,7 +511,7 @@ class CourseListings extends PureComponent {
 
     // Bind our functions
     this.setListingFilter = this.setListingFilter.bind(this);
-    this.checkforFilterUrlParam = this.checkforFilterUrlParam.bind(this);
+    this.checkforFilterUrlParams = this.checkforFilterUrlParams.bind(this);
     this.checkforLocationUrlParam = this.checkforLocationUrlParam.bind(this);
     this.updateURL = this.updateURL.bind(this);
   }
@@ -532,19 +532,6 @@ class CourseListings extends PureComponent {
         setQuery({age_min: value.ageMin, age_max: value.ageMax}, {pushState: true})
         break
     }
-    if (this.state.categoryFilter === '') {
-      setQuery({show: 'all'}, {pushState: true})
-    }
-    if (this.state.courseTypeFilter !== '') {
-      setQuery({course_type: this.state.courseTypeFilter}, {pushState: true})
-    }
-    if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
-      setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
-    }
-    if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
-      setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
-    }
-
   }
 
   // Our function to update the listing filters for category, age, date, and course type
@@ -554,7 +541,7 @@ class CourseListings extends PureComponent {
   }
 
   // Check for url query for showing/hiding results.
-  checkforFilterUrlParam() {
+  checkforFilterUrlParams() {
     if (this.props.search.show != undefined) {
       let safeUrlQuery = this.props.search.show.toLowerCase(); // Via Reach Router
 
@@ -575,6 +562,10 @@ class CourseListings extends PureComponent {
           categoryFilter: 'Course',
         });
       }
+    } else {
+      this.setState({
+        categoryFilter: ''
+      })
     }
 
     // Set the ageFilter state based on query params
@@ -585,15 +576,28 @@ class CourseListings extends PureComponent {
           ageMax: this.props.search.age_max
         }
       })
+    } else {
+      this.setState({
+        ageFilter: {
+          ageMin: 0,
+          ageMax: 0
+        }
+      })
     }
 
     // Set the dateFilter state based on query params
     if (this.props.search.date_min !== undefined && this.props.search.date_max !== undefined) {
-      console.log('Date!!')
       this.setState({
         dateFilter: {
           startDate: new Date(this.props.search.date_min),
           endDate: new Date(this.props.search.date_max)
+        }
+      })
+    } else {
+      this.setState({
+        dateFilter: {
+          startDate: '',
+          endDate: ''
         }
       })
     }
@@ -602,6 +606,10 @@ class CourseListings extends PureComponent {
     if (this.props.search.course_type !== undefined) {
       this.setState({
         courseTypeFilter: this.props.search.course_type
+      })
+    } else {
+      this.setState({
+        courseTypeFilter: ''
       })
     }
 
@@ -625,14 +633,27 @@ class CourseListings extends PureComponent {
     }
   }
 
+  // Reset state if back button is hit in browser
+  componentDidUpdate(prevProps) {
+    if (prevProps.search != this.props.search) {
+      this.checkforFilterUrlParams();
+    }
+  }
+
   componentDidMount() {
     /**
      *
      * Check for Url Parameters
      *
      */
+
+    // Set the default query to show all
+    if (this.props.search.show === undefined) {
+      setQuery({show: 'all'}, {pushState: true})
+    }
+
     this.checkforLocationUrlParam();
-    this.checkforFilterUrlParam();
+    this.checkforFilterUrlParams();
     /**
      *
      * Initialize MapboxGL

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -533,21 +533,27 @@ class CourseListings extends PureComponent {
   // Functon to update our URL using history.push API
   updateURL() {
     if (this.state.categoryFilter !== '') {
+      if (this.state.courseTypeFilter !== '') {
+        setQuery({course_type: this.state.courseTypeFilter})
+      }
+      if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
+        setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
+      }
+      if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
+        setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
+      }
       setQuery({show: this.state.categoryFilter.toLowerCase() + 's'}, {pushState: true})
-      if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
-        setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
-      }
-      if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
-        setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
-      }
     } else {
-      setQuery({show: 'all'}, {pushState: true})
-      if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
-        setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
+      if (this.state.courseTypeFilter !== '') {
+        setQuery({course_type: this.state.courseTypeFilter})
       }
       if (this.state.dateFilter.startDate !== '' && this.state.dateFilter.endDate !== '') {
         setQuery({date_min: format(this.state.dateFilter.startDate, 'yyyy-MM-dd'), date_max: format(this.state.dateFilter.endDate, 'yyyy-MM-dd')}, {pushState: true})
       }
+      if (this.state.ageFilter.ageMin !== 0 && this.state.ageFilter.ageMax !== 0) {
+        setQuery({age_min: this.state.ageFilter.ageMin, age_max: this.state.ageFilter.ageMax}, {pushState: true})
+      }
+      setQuery({show: 'all'}, {pushState: true})
     }
 
   }

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -339,6 +339,7 @@ class ListingsResults extends PureComponent {
     const categoryFilter = this.props.categoryFilter;
     const ageFilter = this.props.ageFilter;
     const dateFilter = this.props.dateFilter;
+    const courseTypeFilter = this.props.courseTypeFilter;
 
     // Filter update function
     const setListingFilter = this.props.setListingFilter
@@ -400,6 +401,11 @@ class ListingsResults extends PureComponent {
      else if (isWithinInterval(new Date(course.start_date), { start: dateFilter.startDate, end: dateFilter.endDate })) {return course}
     }
 
+    const filterCourseByType = course => {
+      if (courseTypeFilter === '') {return course}
+      else if (course.course_type_group === courseTypeFilter) {return course}
+    }
+
     const filteredCourseDataByCategory = filter =>
       geoFilteredCourseData.map(node => {
         return {
@@ -419,7 +425,8 @@ class ListingsResults extends PureComponent {
             courses: node.node.courses
               .filter(course => course.category_group_name.includes(filter))
               .filter(course  => filteredCourseByAge(course))
-              .filter(course => filterCourseByDate(course)),
+              .filter(course => filterCourseByDate(course))
+              .filter(course => filterCourseByType(course))
           },
         };
       }, this);
@@ -488,6 +495,7 @@ class CourseListings extends PureComponent {
         startDate: '',
         endDate: ''
       },
+      courseTypeFilter: '',
       /**
        *
        * Mapbox settings
@@ -842,6 +850,7 @@ class CourseListings extends PureComponent {
                 categoryFilter={this.state.categoryFilter}
                 ageFilter={this.state.ageFilter}
                 dateFilter={this.state.dateFilter}
+                courseTypeFilter={this.state.courseTypeFilter}
                 setListingFilter={this.setListingFilter}
                 toggleCategoryFilter={this.toggleCategoryFilter}
                 allCostCodes={allCostCodes}

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -438,6 +438,9 @@ class ListingsResults extends PureComponent {
             <ListingsFilters
               setListingFilter={setListingFilter}
               categoryFilter={categoryFilter}
+              ageFilter={ageFilter}
+              dateFilter={dateFilter}
+              courseTypeFilter={courseTypeFilter}
               courseData={filteredCourseDataByCategory(categoryFilter)}
             />
             <ListingsCounters

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -517,9 +517,20 @@ class CourseListings extends PureComponent {
   }
 
   // Functon to update our URL using history.push API
-  updateURL() {
-    if (this.state.categoryFilter !== '') {
-      setQuery({show: this.state.categoryFilter}, {pushState: true})
+  updateURL(name, value) {
+    switch (name) {
+      case 'categoryFilter':
+        setQuery({show: value}, {pushState: true})
+        break
+      case 'courseTypeFilter':
+        setQuery({course_type: value}, {pushState: true})
+        break
+      case 'dateFilter':
+        setQuery({date_min: format(value.startDate, 'yyyy-MM-dd'), date_max: format(value.endDate, 'yyyy-MM-dd')}, {pushState: true})
+        break
+      case 'ageFilter':
+        setQuery({age_min: value.ageMin, age_max: value.ageMax}, {pushState: true})
+        break
     }
     if (this.state.categoryFilter === '') {
       setQuery({show: 'all'}, {pushState: true})
@@ -538,7 +549,8 @@ class CourseListings extends PureComponent {
 
   // Our function to update the listing filters for category, age, date, and course type
   setListingFilter(name, value) {
-    this.setState({ [name]: value }, this.updateURL)
+    this.setState({ [name]: value })
+    this.updateURL(name, value)
   }
 
   // Check for url query for showing/hiding results.

--- a/web/src/components/library/CourseListings/ListingsCounters/ListingsCounters.js
+++ b/web/src/components/library/CourseListings/ListingsCounters/ListingsCounters.js
@@ -26,7 +26,7 @@ import { ListingsCountersStyle } from './styles.scss';
 // Begin Component
 //////////////////////////////////////////////////////////////////////
 
-// { courseData, toggleCategoryFilter }
+// { courseData, setListingFilter }
 
 export class ListingsCounters extends PureComponent {
   constructor(props) {
@@ -51,7 +51,7 @@ export class ListingsCounters extends PureComponent {
       });
 
       // Run our parent function from CourseListings.js to filter categories.
-      this.props.toggleCategoryFilter(context);
+      this.props.setListingFilter('categoryFilter', context);
 
       // console.log('this.state.activeContext: ' + this.state.activeContext);
       // console.log('this.state.active: ' + this.state.active);
@@ -62,7 +62,7 @@ export class ListingsCounters extends PureComponent {
       });
 
       // Run our parent function from CourseListings.js to filter categories.
-      this.props.toggleCategoryFilter(context);
+      this.props.setListingFilter('categoryFilter', context);
 
       // console.log('this.state.activeContext: ' + this.state.activeContext);
       // console.log('this.state.active: ' + this.state.active);
@@ -72,7 +72,6 @@ export class ListingsCounters extends PureComponent {
   render() {
     const courseData = this.props.courseData;
     const categoryFilter = this.props.categoryFilter;
-    const toggleCategoryFilter = this.props.toggleCategoryFilter;
 
     // console.log('this.state.activeContext: ' + this.state.activeContext);
     // console.log('this.state.active: ' + this.state.active);
@@ -151,9 +150,9 @@ export class ListingsCounters extends PureComponent {
     }) => {
 
       /**
-       * 
+       *
        * For Debugging Only
-       * 
+       *
        */
       // console.log('categoryFilter:');
       // console.log(categoryFilter);
@@ -161,9 +160,9 @@ export class ListingsCounters extends PureComponent {
       // console.log(context);
 
       /**
-       * 
+       *
        * Return counters
-       * 
+       *
        */
       return (
         <ListingsCountersStyle.Item

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -115,6 +115,31 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
       return dateFilterItems
   }
 
+  const createCourseTypeFilterItems = courses => {
+    const courseTypeFilterItems = uniqWith(courses
+      .map(course => {
+        if (course.course_type_group === 'Basic Lego') {
+          return { name: 'LEGO®: Basic', value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Advanced') {
+          return { name: 'LEGO®: Advanced', value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Ninjago' || course.course_type_group === 'Star Wars' || course.course_type_group === 'Super Heroes' || course.course_type_group === 'Other') {
+          return { name: course.course_type_group, value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Lego Robotics') {
+          return { name: 'LEGO® Robotics', value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Pre School') {
+          return { name: 'Pre-School', value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Minecraft') {
+          return { name: 'Minecraft Theme', value: course.course_type_group }
+        }
+      }), isEqual)
+      return courseTypeFilterItems
+  }
+
   const courses = flatten(courseData.map(data => data.node.courses))
 
   // Show the bar
@@ -137,19 +162,10 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
       />
       <ListingsFiltersItem
         label="Course Type"
-        filterName="courseFilter"
+        filterName="courseTypeFilter"
         updateLabel={updateLabel}
-        items={[
-          { name: 'LEGO®: Basic', value: 'Basic Lego' },
-          { name: 'LEGO®: Advanced', value: 'Advanced' },
-          { name: 'Ninjago', value: 'Ninjago' },
-          { name: 'Star Wars', value: 'Star Wars' },
-          { name: 'Super Heroes', value: 'Super Heroes' },
-          { name: 'LEGO® Robotics', value: 'Lego Robotics' },
-          { name: 'Pre-School', value: 'Pre School' },
-          { name: 'Minecraft Theme', value: 'Minecraft' },
-          { name: 'Other', value: 'Other' },
-        ]}
+        setListingFilter={setListingFilter}
+        items={createCourseTypeFilterItems(courses)}
       />
     </ListingsFiltersStyle>
   );

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -27,7 +27,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
   const [state, setState] = useState({
     ageFilterLabel: 'Any Age',
     dateFilterLabel: 'Any Date',
-    courseFilterLabel: 'Course Type'
+    courseTypeFilterLabel: 'Course Type'
   })
 
   // Function to update the label based on selected drop down item
@@ -170,7 +170,7 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
         updateLabel={updateLabel}
       />
       <ListingsFiltersItem
-        label="Course Type"
+        label={state.courseTypeFilterLabel}
         filterName="courseTypeFilter"
         updateLabel={updateLabel}
         setListingFilter={setListingFilter}

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -119,24 +119,33 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
     const courseTypeFilterItems = uniqWith(courses
       .map(course => {
         if (course.course_type_group === 'Basic Lego') {
-          return { name: 'LEGO®: Basic', value: course.course_type_group }
+          return { order: 1, name: 'LEGO®: Basic', value: course.course_type_group }
         }
         else if (course.course_type_group === 'Advanced') {
-          return { name: 'LEGO®: Advanced', value: course.course_type_group }
+          return { order: 2, name: 'LEGO®: Advanced', value: course.course_type_group }
         }
-        else if (course.course_type_group === 'Ninjago' || course.course_type_group === 'Star Wars' || course.course_type_group === 'Super Heroes' || course.course_type_group === 'Other') {
-          return { name: course.course_type_group, value: course.course_type_group }
+        else if (course.course_type_group === 'Ninjago') {
+          return { order: 3, name: course.course_type_group, value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Star Wars') {
+          return { order: 4, name: course.course_type_group, value: course.course_type_group }
+        }
+        else if (course.course_type_group === 'Super Heroes') {
+          return { order: 5, name: course.course_type_group, value: course.course_type_group }
         }
         else if (course.course_type_group === 'Lego Robotics') {
-          return { name: 'LEGO® Robotics', value: course.course_type_group }
+          return { order: 6, name: 'LEGO® Robotics', value: course.course_type_group }
         }
         else if (course.course_type_group === 'Pre School') {
-          return { name: 'Pre-School', value: course.course_type_group }
+          return { order: 7, name: 'Pre-School', value: course.course_type_group }
         }
         else if (course.course_type_group === 'Minecraft') {
-          return { name: 'Minecraft Theme', value: course.course_type_group }
+          return { order: 8, name: 'Minecraft Theme', value: course.course_type_group }
         }
-      }), isEqual)
+        else if (course.course_type_group === 'Other') {
+          return { order: 9, name: course.course_type_group, value: course.course_type_group }
+        }
+      }), isEqual).sort((a,b) => (a.order - b.order))
       return courseTypeFilterItems
   }
 

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -48,8 +48,8 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
             ? updateLabel(filterName, item.name)
             : <ul>
                 {items.map((item, idx) => (
-                  <li>
-                    <div key={idx} onClick={() => {
+                  <li key={idx}>
+                    <div onClick={() => {
                         updateLabel(filterName, item.name)
                         setListingFilter(filterName, item.value)
                       }}

--- a/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
+++ b/web/src/components/library/CourseListings/ListingsFilters/ListingsFilters.js
@@ -44,21 +44,27 @@ export const ListingsFilters = ({ courseData, setListingFilter }) => {
           <Icon Name="carat" />
         </span>
         <ListingsFiltersStyle.FilterList className="list">
-          <ul>
-            {items.map((item, idx) => (
-              <div key={idx} onClick={() => {
-                  updateLabel(filterName, item.name)
-                  setListingFilter(filterName, item.value)
-                }}
-                onKeyDown={() => {
-                  updateLabel(filterName, item.name)
-                  setListingFilter(filterName, item.value)
-                }}
-                role="presentation">
-                <li>{item.name}</li>
-              </div>
-            ))}
-          </ul>
+          {items.length === 1
+            ? updateLabel(filterName, item.name)
+            : <ul>
+                {items.map((item, idx) => (
+                  <li>
+                    <div key={idx} onClick={() => {
+                        updateLabel(filterName, item.name)
+                        setListingFilter(filterName, item.value)
+                      }}
+                      onKeyDown={() => {
+                        updateLabel(filterName, item.name)
+                        setListingFilter(filterName, item.value)
+                      }}
+                      role="button"
+                      tabIndex="0">
+                      {item.name}
+                    </div>
+                  </li>
+                ))}
+            </ul>
+          }
         </ListingsFiltersStyle.FilterList>
       </ListingsFiltersStyle.Item>
     );


### PR DESCRIPTION
# Overview

Add functionality to filter courses by the course type (i.e. Basic LEGO, Star Wars, etc.).

## Details
* Populate course type drop down based on `courseData`.
* Update the displayed list of courses based on course type selection.
* Update the URL query params to reflect course type selection.

## Bonus
* Refactor the `updateUrl` function for clarity.
* Update the state for `CourseListings` component if props have changed. This allows state to be updated form query params when browser back button is pressed.

## QA Instructions

* Visit the [programs page](https://5e56d49aacf5a200090b5746--play-well-staging.netlify.com/programs/?show=all) on the Playwell staging site.
* Enter in a location.
* Selecting a course type filter from the drop down should update the label of the drop down.
* Selecting a course type filter from the drop down should update the list of courses for that date range.
* Selecting a course type filter from the drop down should update the course counters below the drop down.
* Selecting a course type filter from the drop down should update the url with the query parameter for `course_type`
* Selecting the browser's back button should re-update the filter labels.
* Selecting the browser's back button should re-update the course counters and course list.
* Copying the url with query parameters and pasting it into a new window should give the same result.

[#42aer1](https://app.clickup.com/t/42aer1)