### PR TITLE
[FEATURE] Cost code grouping #42aekm

### DIFF
--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -407,6 +407,7 @@ exports.createPages = ({ graphql, actions }) => {
             cost_code: county.cost_code,
             cost_code_name: county.cost_code_name,
             county_id: county.county_id,
+            counties: allCostCodeCounties(county.cost_code),
             name: county.name,
             managers: filteredCountyManagers(county.cost_code),
             parentState: {

--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -384,6 +384,19 @@ exports.createPages = ({ graphql, actions }) => {
           },
         });
 
+        const allCostCodeCounties = cost_code => {
+          const costCodeCounties = result.data.allPlayWellStates.edges.reduce((relatedCounties, node) => {
+            node.node.counties.forEach(stateCounty => {
+              if (stateCounty.cost_code === cost_code) {
+                relatedCounties.push(stateCounty)
+              }
+            })
+            return relatedCounties
+          }, [])
+
+          return costCodeCounties
+        }
+
         //  Create our Cost Code Pages
         createPage({
           path: `/locations/${stateSlug}/${costCodeSlug}`,

--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -568,9 +568,7 @@ exports.createPages = ({ graphql, actions }) => {
               isCostCode: true,
               cost_code: county.cost_code,
               cost_code_name: county.cost_code_name,
-              county_id: county.county_id,
               counties: allCostCodeCounties(county.cost_code),
-              name: county.name,
               managers: filteredCountyManagers(county.cost_code),
               parentState: {
                 id: state.node.state_id,

--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -384,19 +384,6 @@ exports.createPages = ({ graphql, actions }) => {
           },
         });
 
-        const allCostCodeCounties = cost_code => {
-          const costCodeCounties = result.data.allPlayWellStates.edges.reduce((relatedCounties, node) => {
-            node.node.counties.forEach(stateCounty => {
-              if (stateCounty.cost_code === cost_code) {
-                relatedCounties.push(stateCounty)
-              }
-            })
-            return relatedCounties
-          }, [])
-
-          return costCodeCounties
-        }
-
         //  Create our Cost Code Pages
         createPage({
           path: `/locations/${stateSlug}/${costCodeSlug}`,
@@ -407,7 +394,6 @@ exports.createPages = ({ graphql, actions }) => {
             cost_code: county.cost_code,
             cost_code_name: county.cost_code_name,
             county_id: county.county_id,
-            counties: allCostCodeCounties(county.cost_code),
             name: county.name,
             managers: filteredCountyManagers(county.cost_code),
             parentState: {
@@ -557,7 +543,21 @@ exports.createPages = ({ graphql, actions }) => {
            *
            * Create Cost Code Pages if County exists in Cost Code
            *
-           */
+          */
+
+          // Function to get all counties for a given cost code
+          const allCostCodeCounties = cost_code => {
+            const costCodeCounties = result.data.allPlayWellStates.edges.reduce((relatedCounties, node) => {
+              node.node.counties.forEach(stateCounty => {
+                if (stateCounty.cost_code === cost_code) {
+                  relatedCounties.push(stateCounty)
+                }
+              })
+              return relatedCounties
+            }, [])
+
+            return costCodeCounties
+          }
 
           //  Create our Cost Code Pages
           createPage({
@@ -569,6 +569,7 @@ exports.createPages = ({ graphql, actions }) => {
               cost_code: county.cost_code,
               cost_code_name: county.cost_code_name,
               county_id: county.county_id,
+              counties: allCostCodeCounties(county.cost_code),
               name: county.name,
               managers: filteredCountyManagers(county.cost_code),
               parentState: {

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -333,7 +333,7 @@ class ListingsResults extends PureComponent {
     // Our Filters
     const stateId = this.props.stateId;
     const countyId = this.props.countyId;
-    const costCodeId = this.props.costCodeId;
+    const counties = this.props.counties;
 
     // Filter Categories
     const categoryFilter = this.props.categoryFilter;
@@ -363,6 +363,9 @@ class ListingsResults extends PureComponent {
         };
       }, this)
       .filter(client => {
+        if (counties && counties.some(e => e.county_id === client.node.county_id)) {
+          return client
+        }
         if (
           client.node.state_id == stateId ||
           client.node.county_id == countyId
@@ -799,6 +802,7 @@ class CourseListings extends PureComponent {
     const geoData = this.props.geoData;
     const stateId = this.props.stateId;
     const countyId = this.props.countyId;
+    const counties = this.props.pageContext.counties;
     const costCodeId = this.props.costCodeId;
     const pageContext = this.props.pageContext;
     const search = this.props.search;
@@ -837,6 +841,7 @@ class CourseListings extends PureComponent {
                 courseData={courseData}
                 stateId={stateId}
                 countyId={countyId}
+                counties={counties}
                 costCodeId={costCodeId}
                 pageContext={pageContext}
                 urlQuery={search.show} // Utilizes our withLocation(); function at the end of this document.

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -762,7 +762,7 @@ class CourseListings extends PureComponent {
 
           new mapboxgl.Popup()
             .setLngLat(coordinates)
-            .setHTML(description)
+            .setHTML(`<strong>${description}</strong>`)
             .addTo(map);
         });
 

--- a/web/src/components/library/CourseListings/CourseListings.js
+++ b/web/src/components/library/CourseListings/CourseListings.js
@@ -656,15 +656,15 @@ class CourseListings extends PureComponent {
         ? this.props.pageContext.parentState.playwell_state_id // Display State Id.
         : this.props.pageContext.playwell_state_id; // else it's a State and remove parentState and use it's Id.
 
-      const countyId = this.props.pageContext.isCostCode // If CostCode:
-        ? this.props.pageContext.county_id // Display County Id.
-        : this.props.pageContext.isCounty // If County:
+      const countyId = this.props.pageContext.isCounty // If County:
         ? this.props.pageContext.county_id // Display County Id.
         : null; // else it's a State and County Id is no longer needed.
 
+      const counties = this.props.pageContext.isCostCode // If CostCode
+        ? this.props.pageContext.counties // Display all Counties
+        : null;
+
       const costCodeId = this.props.pageContext.isCostCode // If CostCode:
-        ? this.props.pageContext.cost_code // Display Cost Code.
-        : this.props.pageContext.isCounty // If County:
         ? this.props.pageContext.cost_code // Display Cost Code.
         : null; // else it's a State and CostCode is no longer needed.
 
@@ -709,6 +709,7 @@ class CourseListings extends PureComponent {
         const initialMarkers = clientsByLatLong(
           stateId,
           countyId,
+          counties,
           costCodeId,
           clientEdges
         );

--- a/web/src/components/library/CourseMapNav/styles.scss.js
+++ b/web/src/components/library/CourseMapNav/styles.scss.js
@@ -54,6 +54,10 @@ export const CourseMapNavStyle = styled.div`
     max-width: 200px;
   }
 
+  .mapboxgl-popup-content {
+    color: black;
+  }
+
   .inner {
     max-width: ${Root.Site.Width};
     width: 100%;

--- a/web/src/helpers/clientGeoJsonAdapter.js
+++ b/web/src/helpers/clientGeoJsonAdapter.js
@@ -53,6 +53,7 @@ export const clientGeoJsonAdapter = data => {
 export const clientsByLatLong = (
   state_id,
   county_id,
+  counties,
   cost_code,
   clientEdges
 ) => {
@@ -84,8 +85,9 @@ export const clientsByLatLong = (
    * Check for Cost Code
    */
   if (cost_code != null || cost_code != undefined) {
+    const countyIds = counties.map(county => county.county_id)
     filteredClients = filteredClients.filter(
-      client => parseInt(client.node.state_id) === parseInt(state_id)
+      client => countyIds.includes(client.node.county_id)
     );
   }
 

--- a/web/src/templates/Location/index.js
+++ b/web/src/templates/Location/index.js
@@ -83,12 +83,12 @@ const LocationDetail = ({ pageContext }) => {
         '/' +
         slugify(pageContext.cost_code_name.toLowerCase()) +
         '/' +
-        slugify(pageContext.name.toLowerCase())
+        slugify(pageContext.name.toLowerCase()) + '/'
       : pageContext.isCostCode == true
       ? slugify(pageContext.parentState.name.toLowerCase()) +
         '/' +
-        slugify(pageContext.cost_code_name.toLowerCase())
-      : slugify(pageContext.name.toLowerCase());
+        slugify(pageContext.cost_code_name.toLowerCase()) + '/'
+      : slugify(pageContext.name.toLowerCase()) + '/';
 
   // Build Page
   return (

--- a/web/src/templates/Programs/index.js
+++ b/web/src/templates/Programs/index.js
@@ -67,7 +67,7 @@ const ProgramsPage = ({ pageContext, location }) => {
       <CourseListings
         stateId={pageContext.playwell_state_id}
         countyId={pageContext.county_id}
-        costCodeId={pageContext.cost_code_id}
+        costCodeId={pageContext.cost_code}
         pageContext={pageContext}
         courseData={fetchedData}
         geoData={fetchedData.allPlayWellStates}


### PR DESCRIPTION
# Overview

While building the `/programs` pages in `gatsby-node.js`, the logic originally set a single `county_id` associated with a `cost_code`. Thus, when these pages were visited, only programs for one `county` were visible, rather than programs for all `counties` in the `cost_code`. This PR fixes the issue, passing an array of counties to the program pages for cost codes.

## Details

* Create an `Array.reduce()` function in `gatsby-node.js` to get all `counties` for a give `cost_code`
* Pass the array of `counties` to programs pages through the `pageContext`
* Load map markers for all courses based on the `counties` related to each `cost_code`
* Display a list of all the courses for all `counties` within the viewed `cost_code`

## Bonus

* Fix map popup so that is displays the client title when clicked

[#42aekm](https://app.clickup.com/t/42aekm)